### PR TITLE
applet.js: Change TextIconApplet to IconApplet

### DIFF
--- a/files/fw_fanctrl@juleskreuer.eu/applet.js
+++ b/files/fw_fanctrl@juleskreuer.eu/applet.js
@@ -14,7 +14,7 @@ const AppletSettings = imports.ui.settings;
 const UUID = "fw_fanctrl@juleskreuer.eu";
 const APPLET_DIR = imports.ui.appletManager.appletMeta[UUID].path;
 
-class FW_CONTROL extends Applet.TextIconApplet {
+class FW_CONTROL extends Applet.IconApplet {
     constructor(metadata, orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
         this.applet_dir = metadata.path;


### PR DESCRIPTION
This change would prevent there from being a large gap when the panel is in a vertical orientation.
Before:
![Screenshot from 2025-04-09 20-10-07](https://github.com/user-attachments/assets/c6f7b4ae-ec0d-4014-a2fa-8755734ec7d3)
After:
![Screenshot from 2025-04-09 20-10-46](https://github.com/user-attachments/assets/bc994a61-78ad-4430-81c2-76b1fe6f7cd6)
